### PR TITLE
Fix for no score available continuously popping toaster once score be…

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -49,7 +49,7 @@
         const domain = extractRootDomain(sender.tab.url);
 
         if (domain !== undefined) {
-            getPrivacyScoreLocal(message, sender.tab.id, domain, Date.now());
+            getPrivacyScoreLocal(message, sender.tab.id, domain);
         }
     }
 
@@ -67,38 +67,31 @@
                     body: JSON.stringify({domain: url})
                 });
             })();
-
-
-            browser.tabs.sendMessage(tabId, {
-                message: 'saveScoreInLocalstorage',
-                sentToAnalyze: true,
-            })
-
         }
     }
 
-    function getPrivacyScoreLocal(message, tabId, domain, now){
+    function getPrivacyScoreLocal(message, tabId, domain){
         localforage.getItem(domain).then(function(item) {
-            if(item && item.score && !hasExpired(item.scoreDate, now)) {
+            if(item && item.score && !hasExpired(item.scoreDate)) {
                 // domain score is available locally and has not gone stale
-                sendDataToContentScript(tabId, domain, item, now);
+                sendDataToContentScriptHidden(tabId, domain, item);
             } else if(
                 !item ||
-                (item && !item.score && hasNoScoreAvailableExpired(item.scoreDate, now)) ||
-                (item && item.score && hasExpired(item.scoreDate, now))
+                (item && !item.score && hasExpired(item.scoreDate, expiration.noScoreExpirationDays)) ||
+                (item && item.score && hasExpired(item.scoreDate, expiration.lastScoreExpirationDays))
             ) {
                 // domain score was not found
                 // OR domain score was not found last time we checked
                 // OR domain score has gone stale
                 // fetch again
-                getPrivacyScoreAPI(message, tabId, domain, now);
+                getPrivacyScoreAPI(message, tabId, domain);
             } else {
                 sendDomainNotFound(domain, tabId);
             }
         });
     }
 
-    async function getPrivacyScoreAPI(message, tabId, domain, now) {
+    async function getPrivacyScoreAPI(message, tabId, domain) {
         await fetch(`${urls.baseURL}/score?q=${domain}`).then( response => {
             if(response.status === 404) {
                 return null;
@@ -108,23 +101,21 @@
 
             throw new Error(`Unable to complete privacymonitor.com API request (HTTP ${response.status})`);
         }).then(result => {
-            if (result) {
+            if (result && result.score) {
                 const data = {
                     score: result.score,
                     previousScore: result.previousScore,
-                    scoreDate: now,
-                    lastAutoToastDate: now
+                    scoreDate: Date.now()
                 };
 
                 storePrivacyScore(domain, data);
 
-                sendDataToContentScript(tabId, domain, data, now);
+                sendDataToContentScriptActive(tabId, domain, data);
             } else {
                 const data = {
                     score: null,
                     previousScore: null,
-                    scoreDate: now,
-                    lastAutoToastDate: now
+                    scoreDate: Date.now()
                 };
 
                 storePrivacyScore(domain, data);
@@ -135,18 +126,9 @@
     }
 
     function sendDomainNotFound(domain, tabId) {
-        browser.tabs.sendMessage( tabId, {
+        chrome.tabs.sendMessage( tabId, {
             message: 'NotFound',
             domain: domain
-        });
-    }
-
-    function updateLastAutoToast(domain, now) {
-        localforage.getItem(domain).then(function (item) {
-            if(item !== null){
-                item.lastAutoToastDate = now;
-                localforage.setItem(domain, item );
-            }
         });
     }
 
@@ -154,40 +136,41 @@
         localforage.setItem(domain, data);
     }
 
-    function sendDataToContentScript(tabId, domain, data, now){
-        browser.browserAction.setIcon({
+    function sendDataToContentScriptActive(tabId, domain, data){
+        chrome.browserAction.setIcon({
             path : {
                 '48': 'css/images/iconColored.png'
             },
             tabId : tabId
         });
 
-        if(data.lastAutoToastDate === null || data.lastAutoToastDate === now || hasExpired(data.lastAutoToastDate, now)){
-            updateLastAutoToast(domain, now);
-            browser.tabs.sendMessage( tabId, {
-                message: 'ActiveTabScore',
-                score: data.score,
-                previousScore: data.previousScore,
-                domain: domain
-            });
-        } else {
-            browser.tabs.sendMessage( tabId, {
-                message: 'HiddenTabScore',
-                score: data.score,
-                previousScore: data.previousScore,
-                domain: domain
-            });
-        }
+        chrome.tabs.sendMessage( tabId, {
+            message: 'ActiveTabScore',
+            score: data.score,
+            previousScore: data.previousScore,
+            domain: domain
+        });
     }
 
-    function hasExpired(then, now) {
-        const expireTime = Number(then) + (expiration.lastScoreExpirationDays * 86400 * 1000);
-        return expireTime < now;
+    function sendDataToContentScriptHidden(tabId, domain, data){
+        chrome.browserAction.setIcon({
+            path : {
+                '48': 'css/images/iconColored.png'
+            },
+            tabId : tabId
+        });
+
+        chrome.tabs.sendMessage( tabId, {
+            message: 'HiddenTabScore',
+            score: data.score,
+            previousScore: data.previousScore,
+            domain: domain
+        });
     }
 
-    function hasNoScoreAvailableExpired(then, now) {
-        const expireTime = Number(then) + (expiration.noScoreExpirationDays * 86400 * 1000);
-        return expireTime < now;
+    function hasExpired(then, expirationDays) {
+        const expireTime = Number(then) + (expirationDays * 86400 * 1000);
+        return expireTime < Date.now();
     }
 
     function extractRootDomain(urlStr){


### PR DESCRIPTION
…comes available.

The scoring summary toaster was popping on every request made when the score did not previously exist and then scoring became available for the given domain. Also adjusted logic to recheck no score available scenarios up to once per day. Known domain scores will stay on a 30-day timer for scoring recheck and pop.